### PR TITLE
Hotfix - linting tooling

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "requires": true,
   "packages": {},
   "devDependencies": {
-    "husky": "^7.0.4",
+    "husky": "^7.0.0",
     "lint-staged": "^12.1.4",
     "node-sass": "^4.12.0",
-    "prettier": "^1.18.2"
+    "prettier": "^1.19.1"
   },
   "scripts": {
     "prepare": "husky install",


### PR DESCRIPTION
Reinstalled prettier tooling for linting

Uses this install instead:
https://prettier.io/docs/en/precommit.html#option-2-pretty-quickhttpsgithubcomazzpretty-quick